### PR TITLE
fix(*): update steam avatar urls

### DIFF
--- a/nginx/templates/default.conf.template
+++ b/nginx/templates/default.conf.template
@@ -9,7 +9,7 @@ server {
   add_header X-Content-Type-Options nosniff;
   add_header Cross-Origin-Opener-Policy same-origin;
   add_header Cross-Origin-Embedder-Policy require-corp;
-  add_header Content-Security-Policy "default-src 'self' https://${API_URL} wss://${API_URL}; object-src 'none'; img-src 'self' https://steamcdn-a.akamaihd.net https://static-cdn.jtvnw.net; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'";
+  add_header Content-Security-Policy "default-src 'self' https://${API_URL} wss://${API_URL}; object-src 'none'; img-src 'self' https://steamcdn-a.akamaihd.net https://avatars.akamai.steamstatic.com https://static-cdn.jtvnw.net; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'";
 
   location / {
     root   /usr/share/nginx/html;


### PR DESCRIPTION
This new URL is needed due to CORS headers.